### PR TITLE
chore: MySQL 및 JPA 설정 #16

### DIFF
--- a/.github/workflows/ci_and_cd.yml
+++ b/.github/workflows/ci_and_cd.yml
@@ -46,6 +46,9 @@ jobs:
           
           echo "ENV SPRING_PROFILES_ACTIVE=${{ secrets.SPRING_PROFILES_ACTIVE }}" >> dockerfile.temp
           echo "ENV LOGGING_LEVEL=${{ secrets.LOGGING_LEVEL }}" >> dockerfile.temp
+          echo "ENV DATABASE_JDBC_URL=${{ secrets.DATABASE_JDBC_URL }}" >> dockerfile.temp
+          echo "ENV MYSQL_USERNAME=${{ secrets.MYSQL_USERNAME }}" >> dockerfile.temp
+          echo "ENV MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> dockerfile.temp
           
           mv dockerfile.temp dockerfile
 

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -12,6 +12,9 @@ jobs:
 
     env:
       SPRING_PROFILES_ACTIVE: test
+      DATABASE_JDBC_URL: ${{ secrets.DATABASE_JDBC_URL }}
+      MYSQL_USERNAME: ${{ secrets.MYSQL_USERNAME }}
+      MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
 
     steps:
       - name: 코드 체크아웃

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 	testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.10.2'
 	compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 	testCompileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 	testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ apply from: "$rootDir/sonarqube.gradle"
 dependencies {
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter', version: springBootVersion
 	testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-log4j2', version: springBootVersion
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: springBootVersion
 	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: springBootVersion

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.0.2'
 	testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.10.2'
 	compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 	testCompileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
 	testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: lombokVersion

--- a/src/main/java/com/v/hana/Application.java
+++ b/src/main/java/com/v/hana/Application.java
@@ -4,9 +4,10 @@ import com.v.hana.common.annotation.MethodInfo;
 import com.v.hana.common.annotation.TypeInfo;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 
 @TypeInfo(name = "Application", description = "어플리케이션 클래스")
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 public class Application {
 
     @MethodInfo(name = "main", description = "어플리케이션을 실행합니다.")

--- a/src/main/java/com/v/hana/constant/Gender.java
+++ b/src/main/java/com/v/hana/constant/Gender.java
@@ -1,5 +1,6 @@
 package com.v.hana.constant;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE,
+    FEMALE
 }

--- a/src/main/java/com/v/hana/constant/Gender.java
+++ b/src/main/java/com/v/hana/constant/Gender.java
@@ -1,0 +1,5 @@
+package com.v.hana.constant;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/com/v/hana/entity/User.java
+++ b/src/main/java/com/v/hana/entity/User.java
@@ -1,0 +1,70 @@
+package com.v.hana.entity;
+
+import com.v.hana.constant.Gender;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.sql.Timestamp;
+import java.time.LocalDate; // LocalDateTime 대신 LocalDate를 임포트합니다.
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) //Entity e = new Entity()
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private long id;
+
+    @Column(name = "username", nullable = false)
+    private String username;
+
+    @Column(name = "pw", nullable = false)
+    private String pw;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "birthday", nullable = false)
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthday; // LocalDateTime 대신 LocalDate로 변경합니다.
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "gender", nullable = false, columnDefinition = "INT")
+    private Gender gender;
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private Timestamp updatedAt;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+
+    @Column(name = "is_receive_email")
+    private boolean isReceiveEmail = true;
+
+    @Column(name = "is_receive_alarm")
+    private boolean isReceiveAlarm = true;
+
+    @Builder
+    public User(String username, String pw, String email, String name, Gender gender, LocalDate birthday) { // LocalDateTime 대신 LocalDate로 변경합니다.
+        this.username = username;
+        this.pw = pw;
+        this.email = email;
+        this.name = name;
+        this.gender = gender;
+        this.birthday = birthday;
+    }
+}

--- a/src/main/java/com/v/hana/entity/User.java
+++ b/src/main/java/com/v/hana/entity/User.java
@@ -2,19 +2,17 @@ package com.v.hana.entity;
 
 import com.v.hana.constant.Gender;
 import jakarta.persistence.*;
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import java.sql.Timestamp;
-import java.time.LocalDate; // LocalDateTime 대신 LocalDate를 임포트합니다.
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "users")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) //Entity e = new Entity()
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // Entity e = new Entity()
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,7 +33,7 @@ public class User {
 
     @Column(name = "birthday", nullable = false)
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    private LocalDate birthday; // LocalDateTime 대신 LocalDate로 변경합니다.
+    private LocalDate birthday;
 
     @Enumerated(EnumType.ORDINAL)
     @Column(name = "gender", nullable = false, columnDefinition = "INT")
@@ -59,7 +57,13 @@ public class User {
     private boolean isReceiveAlarm = true;
 
     @Builder
-    public User(String username, String pw, String email, String name, Gender gender, LocalDate birthday) { // LocalDateTime 대신 LocalDate로 변경합니다.
+    public User(
+            String username,
+            String pw,
+            String email,
+            String name,
+            Gender gender,
+            LocalDate birthday) {
         this.username = username;
         this.pw = pw;
         this.email = email;

--- a/src/main/java/com/v/hana/repository/UserRepository.java
+++ b/src/main/java/com/v/hana/repository/UserRepository.java
@@ -1,9 +1,8 @@
 package com.v.hana.repository;
 
 import com.v.hana.entity.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);

--- a/src/main/java/com/v/hana/repository/UserRepository.java
+++ b/src/main/java/com/v/hana/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.v.hana.repository;
+
+import com.v.hana.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findById(Long id);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
   show-sql: true
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,19 @@ server:
 spring:
   application:
     name: hana-v
+  datasource:
+   url: ${DATABASE_JDBC_URL}
+   username: ${MYSQL_USERNAME}
+   password: ${MYSQL_PASSWORD}
+   driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+   properties:
+     hibernate:
+       dialect: org.hibernate.dialect.MySQLDialect
+       format_sql: true
+  hibernate:
+     ddl-auto: create
+  show-sql: true
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,17 +4,17 @@ spring:
   application:
     name: hana-v
   datasource:
-   url: ${DATABASE_JDBC_URL}
-   username: ${MYSQL_USERNAME}
-   password: ${MYSQL_PASSWORD}
-   driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DATABASE_JDBC_URL}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
-   properties:
-     hibernate:
-       dialect: org.hibernate.dialect.MySQLDialect
-       format_sql: true
-  hibernate:
-     ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+    hibernate:
+      ddl-auto: create
   show-sql: true
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/src/main/resources/db.sql
+++ b/src/main/resources/db.sql
@@ -1,0 +1,127 @@
+-- schema 생성
+CREATE DATABASE IF NOT EXISTS hanaVdb;
+USE hanaVdb;
+
+drop table if exists users;
+CREATE TABLE `users` (
+                         `id`	bigint PRIMARY KEY AUTO_INCREMENT,
+                         `username`	varchar(32)	NOT NULL unique,
+                         `pw`	varchar(255)	NOT NULL,
+                         `name`	varchar(255)	NOT NULL,
+                         `email`	varchar(255)	NOT NULL unique,
+                         `birthday`	date	NOT NULL,
+                         `gender`	int	NOT NULL,
+                         `created_at`	datetime	NOT NULL,
+                         `updated_at`	datetime	NOT NULL,
+                         `is_deleted`	boolean	NULL,
+                         `is_receive_email`	boolean	NOT NULL,
+                         `is_receive_alarm`	boolean	NOT NULL
+);
+
+drop table if exists accounts;
+CREATE TABLE `accounts` (
+                            `id`	bigint PRIMARY KEY	AUTO_INCREMENT,
+                            `user_id`	bigint	NOT NULL,
+                            `account_number`	varchar(255)	NOT NULL unique,
+                            `balance`	bigint	NOT NULL,
+                            `registered_at`	datetime	NOT NULL,
+                            `is_deleted`	boolean	NULL,
+                            `bank_name`	varchar(50)	NOT NULL,
+                            CONSTRAINT fk_users_to_accounts FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+drop table if exists categories;
+CREATE TABLE `categories` (
+                              `id`	bigint PRIMARY KEY	AUTO_INCREMENT,
+                              `title`	varchar(50)	NOT NULL unique,
+                              `color`	varchar(50)	NOT NULL
+);
+
+drop table if exists interests;
+CREATE TABLE `interests` (
+                             `id`	bigint PRIMARY KEY	AUTO_INCREMENT,
+                             `title`	varchar(30)	NOT NULL unique,
+                             `description`	varchar(255)	NULL,
+                             `base_image_url`	varchar(255)	NOT NULL,
+                             `color`	varchar(50)	NOT NULL
+);
+
+drop table if exists cards;
+CREATE TABLE `cards` (
+                         `id`	bigint PRIMARY KEY	AUTO_INCREMENT,
+                         `name`	varchar(255)	NOT NULL unique
+);
+
+drop table if exists cards_benefits;
+CREATE TABLE `cards_benefits` (
+                                  `id`	bigint	primary key auto_increment,
+                                  `card_id`	bigint	NOT NULL,
+                                  `group`	varchar(30)	NULL,
+                                  `title`	varchar(30)	NOT NULL,
+                                  `description`	varchar(255)	NULL,
+                                  CONSTRAINT fk_cards_to_cb FOREIGN KEY (card_id) REFERENCES cards(id)
+);
+
+drop table if exists card_interests;
+CREATE TABLE `card_interests` (
+                                  `id`	bigint PRIMARY KEY	auto_increment,
+                                  `card_id`	bigint	NOT NULL,
+                                  `interest_id`	bigint	NOT NULL,
+                                  CONSTRAINT fk_cards_to_ci FOREIGN KEY (card_id) REFERENCES cards(id),
+                                  CONSTRAINT fk_interests_to_ci FOREIGN KEY (interest_id) REFERENCES interests(id)
+);
+
+drop table if exists user_interests;
+CREATE TABLE `user_interests` (
+                                  `id`	bigint PRIMARY KEY	auto_increment,
+                                  `user_id`	bigint	NOT NULL,
+                                  `interest_id`	bigint	NOT NULL,
+                                  `subtitle`	varchar(30)	NULL,
+                                  `image_url`	varchar(255)	NOT NULL,
+                                  CONSTRAINT unique_user_interest_pair UNIQUE (user_id, interest_id),
+                                  CONSTRAINT fk_users_to_user_interests FOREIGN KEY (user_id) REFERENCES users(id),
+                                  CONSTRAINT fk_interests_to_user_interests FOREIGN KEY (interest_id) REFERENCES interests(id)
+);
+
+drop table if exists transaction_histories;
+CREATE TABLE `transaction_histories` (
+                                         `id`	bigint PRIMARY KEY	auto_increment,
+                                         `account_id`	bigint	NOT NULL,
+                                         `user_id`	bigint	NOT NULL,
+                                         `category_id`	bigint	NOT NULL,
+                                         `approval_number`	int	NOT NULL,
+                                         `type`	varchar(50)	NOT NULL,
+                                         `description`	varchar(255)	 NOT NULL,
+                                         `action`	varchar(10)	NOT NULL,
+                                         `amount`	bigint	NOT NULL,
+                                         `balance`	int	NOT NULL,
+                                         `created_at`	datetime	NOT NULL,
+                                         `updated_at`	datetime	NOT NULL,
+                                         CONSTRAINT fk_users_to_th FOREIGN KEY (user_id) REFERENCES users(id),
+                                         CONSTRAINT fk_accounts_to_th FOREIGN KEY (account_id) REFERENCES accounts(id),
+                                         CONSTRAINT fk_categories_to_th FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+drop table if exists transaction_history_details;
+CREATE TABLE `transaction_history_details` (
+                                               `id`	bigint PRIMARY KEY	auto_increment,
+                                               `transaction_history_id`	bigint	NOT NULL,
+                                               `user_id`	bigint	NOT NULL,
+                                               `interest_id`	bigint	NOT NULL,
+                                               `description`	varchar(255)	NOT NULL,
+                                               `amount`	bigint	NOT NULL,
+                                               `created_at`	datetime	NOT NULL,
+                                               `updated_at`	datetime	NOT NULL,
+                                               `is_deleted`	boolean	NOT NULL,
+                                               CONSTRAINT fk_users_to_thd FOREIGN KEY (user_id) REFERENCES users(id),
+                                               CONSTRAINT fk_interests_to_thd FOREIGN KEY (interest_id) REFERENCES interests(id),
+                                               CONSTRAINT fk_transaction_histories_to_thd FOREIGN KEY (transaction_history_id) REFERENCES transaction_histories(id)
+);
+
+drop table if exists account_api;
+CREATE TABLE `account_api` (
+                               `id`	bigint PRIMARY KEY	auto_increment,
+                               `bank_name`	varchar(50)	NOT NULL,
+                               `account_number`	varchar(255)	NOT NULL unique,
+                               `balance`	bigint	NOT NULL
+);

--- a/src/test/java/com/v/hana/JpaTests.java
+++ b/src/test/java/com/v/hana/JpaTests.java
@@ -1,37 +1,38 @@
 package com.v.hana;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.v.hana.constant.Gender;
 import com.v.hana.entity.User;
 import com.v.hana.repository.UserRepository;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 class JpaTests {
-    @Autowired
-    private UserRepository userRepository;
+    @Autowired private UserRepository userRepository;
 
     @Test
     @DisplayName("유저 생성 테스트")
-    void insert_user(){
-        //유저 등록
-        User user = userRepository.save(User.builder()
-                .birthday(LocalDate.from(LocalDateTime.now())).email("borieya0619@gmail.com")
-                .pw("123").name("박효리")
-                .gender(Gender.FEMALE).username("박효리").build());
+    void insert_user() {
+        // 유저 등록
+        User user =
+                userRepository.save(
+                        User.builder()
+                                .birthday(LocalDate.from(LocalDateTime.now()))
+                                .email("borieya0619@gmail.com")
+                                .pw("123")
+                                .name("박효리")
+                                .gender(Gender.FEMALE)
+                                .username("박효리")
+                                .build());
 
         Optional<User> optionalUser = userRepository.findById(user.getId());
         assertEquals(user.getUsername(), optionalUser.get().getUsername());
     }
-
 }

--- a/src/test/java/com/v/hana/JpaTests.java
+++ b/src/test/java/com/v/hana/JpaTests.java
@@ -1,0 +1,37 @@
+package com.v.hana;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.v.hana.constant.Gender;
+import com.v.hana.entity.User;
+import com.v.hana.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@DataJpaTest
+class JpaTests {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("유저 생성 테스트")
+    void insert_user(){
+        //유저 등록
+        User user = userRepository.save(User.builder()
+                .birthday(LocalDate.from(LocalDateTime.now())).email("borieya0619@gmail.com")
+                .pw("123").name("박효리")
+                .gender(Gender.FEMALE).username("박효리").build());
+
+        Optional<User> optionalUser = userRepository.findById(user.getId());
+        assertEquals(user.getUsername(), optionalUser.get().getUsername());
+    }
+
+}


### PR DESCRIPTION
datasource settings & add depedency at runtime

## 📍 제목
MySQL 및 JPA 설정

## 📃 목적
이번 이슈애서는 프로젝트의 데이터 관리 및 접근을 효율적으로 수행하기 위해 MySQL 데이터베이스와 Java Persistence API (JPA)를 올바르게 설정하고 구성하는 과정을 다룹니다.

## 📋 내용
프로젝트에 MySQL 연동
프로젝트의 application.yml 파일에서 MySQL 데이터베이스 설정
데이터베이스 연결 URL, 사용자명, 비밀번호 설정
JPA 관련 기본 설정 (Hibernate 사용 시 Dialect 설정 등)
JPA 설정
JPA 의존성 추가
예시 클래스에 엔티티, 레포지토리 클래스 추가 및 테스트

## ❗ 체크리스트
<!-- 이번 PR을 제출하기 전에 확인할 사항들을 체크하세요. -->

- [ ] 코드가 의도한 대로 동작합니다.
- [ ] 기존 테스트를 모두 통과합니다.
- [ ] 추가된 새로운 테스트를 모두 통과합니다.
- [ ] 코드 스타일 규칙을 준수하였습니다.
- [ ] PR 템플릿 형식에 맞게 작성하였습니다.
- [ ] PR 이슈, 기여자, 라벨을 지정하였습니다.

## 📷 스크린샷 (선택)
<!-- 이번 PR에 대한 예시 화면을 스크린샷으로 첨부하세요. -->

## ❓ 추가 설명 (선택)
<!-- 이번 PR에 대한 추가 설명, 혹은 코드 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성하세요. -->

## 🔗 관련 문서 (선택)
<!-- 이번 PR과 관련된 문서나 참고 링크가 있다면 추가하세요. -->
