### PR TITLE
feat: JWT 인증 처리 & 사용자 정보 식별 핸들러

### DIFF
--- a/.github/workflows/ci_and_cd.yml
+++ b/.github/workflows/ci_and_cd.yml
@@ -58,6 +58,9 @@ jobs:
           echo "ENV REDIS_PORT=${{ secrets.REDIS_PORT }}" >> dockerfile.temp
           echo "ENV REDIS_VOLUME=${{ secrets.REDIS_VOLUNE }}" >> dockerfile.temp
           echo "ENV REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}" >> dockerfile.temp
+          echo "ENV JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}" >> dockerfile.temp
+          echo "ENV REFRESH_TOKEN_EXPIRATION=${{ secrets.REFRESH_TOKEN_EXPIRATION }}" >> dockerfile.temp
+          echo "ENV ACCESS_TOKEN_EXPIRATION=${{ secrets.ACCESS_TOKEN_EXPIRATION }}" >> dockerfile.temp
           
           
           mv dockerfile.temp dockerfile

--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -24,6 +24,9 @@ jobs:
       REDIS_PORT: ${{ secretes.REDIS_PORT }}
       REDIS_PASSWORD: ${{ secretes.REDIS_PASSWORD }}
       REDIS_VOLUME: ${{ secrets.REDIS_VOLUME }}
+      JWT_SECRET_KEY: ${{ secerts.JWT_SECRET_KEY }}
+      ACCESS_TOKEN_EXPIRATION: ${{ secrets.ACCESS_TOKEN_EXPIRATION }}
+      REFRESH_TOKEN_EXPIRATION: ${{ secrets.REFRESH_TOKEN_EXPIRATION }}
 
     steps:
       - name: 코드 체크아웃

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,13 @@ dependencies {
 	implementation 'org.springframework:spring-context-support:5.3.9'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 openapi3 {

--- a/src/main/java/com/v/hana/auth/annotation/CurrentUser.java
+++ b/src/main/java/com/v/hana/auth/annotation/CurrentUser.java
@@ -1,0 +1,12 @@
+package com.v.hana.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal
+public @interface CurrentUser {}

--- a/src/main/java/com/v/hana/auth/config/SecurityConfig.java
+++ b/src/main/java/com/v/hana/auth/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.v.hana.auth.config;
+
+import com.v.hana.auth.filter.JwtAuthenticationFilter;
+import com.v.hana.auth.provider.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .sessionManagement(
+                        (session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(
+                        (authz) ->
+                                authz.requestMatchers(
+                                                "/swagger-ui/**",
+                                                "/v1/api/users",
+                                                "v1/api/users/login",
+                                                "v1/api/users/new_access_token")
+                                        .permitAll()
+                                        .anyRequest()
+                                        .authenticated())
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/src/main/java/com/v/hana/auth/config/SecurityConfig.java
+++ b/src/main/java/com/v/hana/auth/config/SecurityConfig.java
@@ -33,7 +33,12 @@ public class SecurityConfig {
                                                 "/swagger-ui/**",
                                                 "/v1/api/users/join",
                                                 "v1/api/users/login",
-                                                "v1/api/users/new_token")
+                                                "v1/api/users/new_token",
+                                                "v1/api/users/check_dup",
+                                                "v1/api/users/update/pw",
+                                                "v1/api/users/find/username",
+                                                "v1/api/emails/authcode",
+                                                "v1/api/emails/check/authcode")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/src/main/java/com/v/hana/auth/config/SecurityConfig.java
+++ b/src/main/java/com/v/hana/auth/config/SecurityConfig.java
@@ -31,9 +31,9 @@ public class SecurityConfig {
                         (authz) ->
                                 authz.requestMatchers(
                                                 "/swagger-ui/**",
-                                                "/v1/api/users",
+                                                "/v1/api/users/join",
                                                 "v1/api/users/login",
-                                                "v1/api/users/new_access_token")
+                                                "v1/api/users/new_token")
                                         .permitAll()
                                         .anyRequest()
                                         .authenticated())

--- a/src/main/java/com/v/hana/auth/dto/CustomUserDetails.java
+++ b/src/main/java/com/v/hana/auth/dto/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package com.v.hana.auth.dto;
+
+import com.v.hana.entity.user.User;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null; // 필요한 경우 권한을 반환하도록 수정 가능
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPw();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/v/hana/auth/dto/JwtToken.java
+++ b/src/main/java/com/v/hana/auth/dto/JwtToken.java
@@ -1,0 +1,12 @@
+package com.v.hana.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class JwtToken {
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/v/hana/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/v/hana/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.v.hana.auth.filter;
+
+import com.v.hana.auth.dto.CustomUserDetails;
+import com.v.hana.auth.provider.JwtTokenProvider;
+import com.v.hana.entity.user.User;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String token = resolveToken((HttpServletRequest) request);
+
+        if (token != null) {
+            try {
+                User user = jwtTokenProvider.getUser(token);
+                CustomUserDetails userDetails = new CustomUserDetails(user);
+                Authentication authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails, "", userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (RuntimeException e) {
+                HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+                httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                httpServletResponse.setContentType("application/json");
+                httpServletResponse.setCharacterEncoding("UTF-8");
+                String jsonResponse = String.format("{\"error\": \"%s\"}", e.getMessage());
+                httpServletResponse.getWriter().write(jsonResponse);
+                return; // 예외 발생 시 필터 체인을 중단하고 응답을 반환
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/v/hana/auth/provider/JwtTokenProvider.java
+++ b/src/main/java/com/v/hana/auth/provider/JwtTokenProvider.java
@@ -71,17 +71,17 @@ public class JwtTokenProvider {
 
     // 인증 토큰으로 유저 정보 불러오기
     public User getUser(String token) {
-            this.validateToken(token);
-            Claims claims =
-                    Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
-            if (claims.get("username") == null) {
-                throw new RuntimeException("유저 정보가 없는 토큰입니다.");
-            }
-            Optional<User> user = userRepository.findByUsername((String) claims.get("username"));
-            if (user.isPresent()) {
-                return user.get();
-            }
-            throw new RuntimeException("해당 아이디의 유저가 존재하지 않습니다.");
+        this.validateToken(token);
+        Claims claims =
+                Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        if (claims.get("username") == null) {
+            throw new RuntimeException("유저 정보가 없는 토큰입니다.");
+        }
+        Optional<User> user = userRepository.findByUsername((String) claims.get("username"));
+        if (user.isPresent()) {
+            return user.get();
+        }
+        throw new RuntimeException("해당 아이디의 유저가 존재하지 않습니다.");
     }
 
     // 인증 토큰 유효성 검사

--- a/src/main/java/com/v/hana/auth/provider/JwtTokenProvider.java
+++ b/src/main/java/com/v/hana/auth/provider/JwtTokenProvider.java
@@ -71,7 +71,6 @@ public class JwtTokenProvider {
 
     // 인증 토큰으로 유저 정보 불러오기
     public User getUser(String token) {
-        try {
             this.validateToken(token);
             Claims claims =
                     Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
@@ -83,9 +82,6 @@ public class JwtTokenProvider {
                 return user.get();
             }
             throw new RuntimeException("해당 아이디의 유저가 존재하지 않습니다.");
-        } catch (ExpiredJwtException e) {
-            throw new RuntimeException("만료된 토큰입니다.");
-        }
     }
 
     // 인증 토큰 유효성 검사
@@ -98,8 +94,8 @@ public class JwtTokenProvider {
                     .getBody()
                     .getExpiration()
                     .after(new Date());
-        } catch (Exception e) {
-            return false;
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("만료된 토큰입니다.");
         }
     }
 }

--- a/src/main/java/com/v/hana/auth/provider/JwtTokenProvider.java
+++ b/src/main/java/com/v/hana/auth/provider/JwtTokenProvider.java
@@ -1,0 +1,105 @@
+package com.v.hana.auth.provider;
+
+import com.v.hana.auth.dto.JwtToken;
+import com.v.hana.entity.user.User;
+import com.v.hana.repository.user.UserRepository;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+    private final Key key;
+    private final UserRepository userRepository;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey, UserRepository userRepository) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.userRepository = userRepository;
+    }
+
+    // refresh access 인증 토큰 발급
+    public JwtToken generateToken(User user) {
+
+        Claims claims = Jwts.claims();
+        claims.put("username", user.getUsername());
+
+        long now = (new Date()).getTime();
+        Date refreshTokenExpiresIn = new Date(now + 86400000); // 24시간 후 만료
+
+        String refreshToken =
+                Jwts.builder()
+                        .setClaims(claims)
+                        .setExpiration(refreshTokenExpiresIn)
+                        .signWith(SignatureAlgorithm.HS256, key)
+                        .compact();
+
+        return this.getAccessToken(refreshToken); // 새 엑세스 토큰 담아 JwtToken 발급
+    }
+
+    public JwtToken getAccessToken(String refreshToken) {
+        // refresh token 으로부터 유저정보 추출해서 새 액세스 토큰 발급
+        this.validateToken(refreshToken);
+        User user = this.getUser(refreshToken);
+        Claims claims = Jwts.claims();
+        claims.put("username", user.getUsername());
+        long now = (new Date()).getTime();
+        Date accessTokenExpiresIn = new Date(now + 900000); // 15분 후 만료
+
+        String newAccessToken =
+                Jwts.builder()
+                        .setClaims(claims) // claims를 먼저 설정
+                        .setSubject(user.getEmail())
+                        .setExpiration(accessTokenExpiresIn) // 그 다음 만료 시간을 설정
+                        .signWith(SignatureAlgorithm.HS256, key)
+                        .compact();
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(newAccessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 인증 토큰으로 유저 정보 불러오기
+    public User getUser(String token) {
+        try {
+            this.validateToken(token);
+            Claims claims =
+                    Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+            if (claims.get("username") == null) {
+                throw new RuntimeException("유저 정보가 없는 토큰입니다.");
+            }
+            Optional<User> user = userRepository.findByUsername((String) claims.get("username"));
+            if (user.isPresent()) {
+                return user.get();
+            }
+            throw new RuntimeException("해당 아이디의 유저가 존재하지 않습니다.");
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("만료된 토큰입니다.");
+        }
+    }
+
+    // 인증 토큰 유효성 검사
+    public boolean validateToken(String accessToken) {
+        try {
+
+            return Jwts.parser()
+                    .setSigningKey(key)
+                    .parseClaimsJws(accessToken)
+                    .getBody()
+                    .getExpiration()
+                    .after(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/v/hana/common/exception/UserHttpCode.java
+++ b/src/main/java/com/v/hana/common/exception/UserHttpCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum UserHttpCode implements BaseHttpCode {
     USER_EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "USER-001", "입력 받은 사용자 이메일이 이미 존재함."),
-    USER_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "USER-002", "입력 받은 사용자 이름이 이미 존재함.");
+    USER_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "USER-002", "입력 받은 사용자 이름이 이미 존재함."),
+    EMPTY_USER(HttpStatus.BAD_REQUEST, "USER-003", "사용자 정보가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/v/hana/common/response/DeleteSuccessResponse.java
+++ b/src/main/java/com/v/hana/common/response/DeleteSuccessResponse.java
@@ -1,0 +1,6 @@
+package com.v.hana.common.response;
+
+import lombok.Builder;
+
+@Builder
+public class DeleteSuccessResponse extends BaseResponse {}

--- a/src/main/java/com/v/hana/common/response/GetSuccessResponse.java
+++ b/src/main/java/com/v/hana/common/response/GetSuccessResponse.java
@@ -1,0 +1,14 @@
+package com.v.hana.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GetSuccessResponse<T> extends BaseResponse {
+    private T data;
+
+    @Builder
+    public GetSuccessResponse(T data) {
+        this.data = data;
+    }
+}

--- a/src/main/java/com/v/hana/common/response/PostSuccessResponse.java
+++ b/src/main/java/com/v/hana/common/response/PostSuccessResponse.java
@@ -1,0 +1,6 @@
+package com.v.hana.common.response;
+
+import lombok.Builder;
+
+@Builder
+public class PostSuccessResponse extends BaseResponse {}

--- a/src/main/java/com/v/hana/controller/email/EmailController.java
+++ b/src/main/java/com/v/hana/controller/email/EmailController.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.*;
 public class EmailController {
     private final MailService mailService;
 
-    @PostMapping("/emails/verification-requests")
+    @PostMapping("/emails/authcode")
     public ResponseEntity sendMessage(@RequestParam("email") @Valid String email) {
         mailService.sendCodeToEmail(email);
 
         return ResponseEntity.status(HttpStatus.OK).body("이메일 전송 완료");
     }
 
-    @GetMapping("/emails/verifications")
+    @GetMapping("/emails/check/authcode")
     public ResponseEntity verificationEmail(
             @RequestParam("email") @Valid String email, @RequestParam("code") String authCode) {
         boolean response = mailService.verifiedCode(email, authCode);

--- a/src/main/java/com/v/hana/controller/user/UserController.java
+++ b/src/main/java/com/v/hana/controller/user/UserController.java
@@ -1,22 +1,24 @@
 package com.v.hana.controller.user;
 
+import com.v.hana.auth.annotation.CurrentUser;
+import com.v.hana.auth.dto.JwtToken;
+import com.v.hana.auth.provider.JwtTokenProvider;
 import com.v.hana.common.annotation.MethodInfo;
 import com.v.hana.common.annotation.TypeInfo;
+import com.v.hana.common.response.PostSuccessResponse;
 import com.v.hana.dto.user.UserJoinRequest;
-import com.v.hana.exception.user.UserEmailDuplicateException;
-import com.v.hana.exception.user.UserNameDuplicateException;
+import com.v.hana.dto.user.UserJwtTokenGetResponse;
+import com.v.hana.dto.user.UserLoginRequest;
+import com.v.hana.entity.user.User;
+import com.v.hana.exception.user.InvalidUserAccessException;
+import com.v.hana.repository.user.UserRepository;
 import com.v.hana.service.user.UserService;
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @TypeInfo(name = "UserController", description = "유저 컨트롤러 클래스")
 @RestController
@@ -24,34 +26,49 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @MethodInfo(name = "user join", description = "유저 컨트롤러의 회원 가입 메소드를 실행합니다.")
     @PostMapping("/users")
-    public ResponseEntity<?> join(@Valid @RequestBody UserJoinRequest userJoinRequest) {
-        try {
-            userService.join(
-                    userJoinRequest.getUsername(),
-                    userJoinRequest.getName(),
-                    userJoinRequest.getPw(),
-                    userJoinRequest.getEmail(),
-                    userJoinRequest.getGender());
-            return ResponseEntity.ok(
-                    Map.of(
-                            "status",
-                            200,
-                            "success",
-                            true,
-                            "timestamp",
-                            LocalDateTime.now()
-                                    .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
-                            "code",
-                            "SUCCESS",
-                            "message",
-                            "User joined successfully",
-                            "response",
-                            1));
-        } catch (UserEmailDuplicateException | UserNameDuplicateException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
-        }
+    public ResponseEntity<PostSuccessResponse> join(
+            @Valid @RequestBody UserJoinRequest userJoinRequest) {
+        userService.join(
+                userJoinRequest.getUsername(),
+                userJoinRequest.getName(),
+                userJoinRequest.getPw(),
+                userJoinRequest.getEmail(),
+                userJoinRequest.getGender());
+        return ResponseEntity.ok(PostSuccessResponse.builder().build());
+    }
+
+    @PostMapping("/users/login") // 액세스 토큰으로 로그인
+    public ResponseEntity<UserJwtTokenGetResponse> login(@RequestBody UserLoginRequest loginRequest) {
+        Optional<User> user =
+                userRepository.findByUsernameAndPw(
+                        loginRequest.getUsername(), loginRequest.getPw());
+        if (user.isEmpty()) throw new InvalidUserAccessException();
+        JwtToken jwtToken = jwtTokenProvider.generateToken(user.get());
+        UserJwtTokenGetResponse userJwtTokenGetResponse = UserJwtTokenGetResponse.builder()
+                .accessToken(jwtToken.getAccessToken())
+                .refreshToken(jwtToken.getRefreshToken())
+                .build();
+        return ResponseEntity.ok(userJwtTokenGetResponse);
+    }
+
+    @GetMapping("users/new_access_token")
+    public ResponseEntity<UserJwtTokenGetResponse> getNewAccessToken(
+            @RequestParam("refresh_token") String refreshToken) {
+        JwtToken jwtToken = jwtTokenProvider.getAccessToken(refreshToken);
+        return ResponseEntity.ok(
+                UserJwtTokenGetResponse.builder()
+                        .accessToken(jwtToken.getAccessToken())
+                        .refreshToken(jwtToken.getRefreshToken())
+                        .build());
+    }
+
+    @GetMapping("/users/username")
+    public String getUserInfo(@CurrentUser UserDetails userDetails, @RequestParam String message) {
+        return "User: " + userDetails.getUsername() + " Message: " + message;
     }
 }

--- a/src/main/java/com/v/hana/controller/user/UserController.java
+++ b/src/main/java/com/v/hana/controller/user/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
     private final UserRepository userRepository;
 
     @MethodInfo(name = "user join", description = "유저 컨트롤러의 회원 가입 메소드를 실행합니다.")
-    @PostMapping("/users")
+    @PostMapping("/users/join")
     public ResponseEntity<PostSuccessResponse> join(
             @Valid @RequestBody UserJoinRequest userJoinRequest) {
         userService.join(
@@ -42,7 +42,7 @@ public class UserController {
         return ResponseEntity.ok(PostSuccessResponse.builder().build());
     }
 
-    @PostMapping("/users/login") // 액세스 토큰으로 로그인
+    @PostMapping("/users/login")
     public ResponseEntity<UserJwtTokenGetResponse> login(@RequestBody UserLoginRequest loginRequest) {
         Optional<User> user =
                 userRepository.findByUsernameAndPw(
@@ -56,7 +56,7 @@ public class UserController {
         return ResponseEntity.ok(userJwtTokenGetResponse);
     }
 
-    @GetMapping("users/new_access_token")
+    @GetMapping("users/new_token")
     public ResponseEntity<UserJwtTokenGetResponse> getNewAccessToken(
             @RequestParam("refresh_token") String refreshToken) {
         JwtToken jwtToken = jwtTokenProvider.getAccessToken(refreshToken);

--- a/src/main/java/com/v/hana/dto/user/UpdateUserInfoRequest.java
+++ b/src/main/java/com/v/hana/dto/user/UpdateUserInfoRequest.java
@@ -1,0 +1,8 @@
+package com.v.hana.dto.user;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateUserInfoRequest {
+    private String email;
+}

--- a/src/main/java/com/v/hana/dto/user/UserChangePwRequest.java
+++ b/src/main/java/com/v/hana/dto/user/UserChangePwRequest.java
@@ -1,0 +1,9 @@
+package com.v.hana.dto.user;
+
+import lombok.Getter;
+
+@Getter
+public class UserChangePwRequest {
+    private String email;
+    private String pw;
+}

--- a/src/main/java/com/v/hana/dto/user/UserGetResponse.java
+++ b/src/main/java/com/v/hana/dto/user/UserGetResponse.java
@@ -1,0 +1,23 @@
+package com.v.hana.dto.user;
+
+import com.v.hana.common.constant.Gender;
+import com.v.hana.common.response.BaseResponse;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserGetResponse extends BaseResponse {
+    private String username;
+    private String email;
+    private LocalDate birthday;
+    private Gender gender;
+
+    @Builder
+    public UserGetResponse(String username, String email, LocalDate birthday, Gender gender) {
+        this.username = username;
+        this.email = email;
+        this.birthday = birthday;
+        this.gender = gender;
+    }
+}

--- a/src/main/java/com/v/hana/dto/user/UserJwtTokenGetResponse.java
+++ b/src/main/java/com/v/hana/dto/user/UserJwtTokenGetResponse.java
@@ -1,0 +1,17 @@
+package com.v.hana.dto.user;
+
+import com.v.hana.common.response.BaseResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserJwtTokenGetResponse extends BaseResponse {
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public UserJwtTokenGetResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/v/hana/dto/user/UserLoginRequest.java
+++ b/src/main/java/com/v/hana/dto/user/UserLoginRequest.java
@@ -1,0 +1,19 @@
+package com.v.hana.dto.user;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@EqualsAndHashCode(callSuper = false)
+public class UserLoginRequest {
+    @NotNull private final String username;
+    @NotNull private final String pw;
+
+    @Builder
+    public UserLoginRequest(String username, String pw) {
+        this.username = username;
+        this.pw = pw;
+    }
+}

--- a/src/main/java/com/v/hana/entity/user/User.java
+++ b/src/main/java/com/v/hana/entity/user/User.java
@@ -5,12 +5,16 @@ import com.v.hana.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // Entity e = new Entity()
+@SQLDelete(sql = "UPDATE users SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/v/hana/exception/user/InvalidUserAccessException.java
+++ b/src/main/java/com/v/hana/exception/user/InvalidUserAccessException.java
@@ -1,0 +1,11 @@
+package com.v.hana.exception.user;
+
+import com.v.hana.common.exception.BaseCodeException;
+import com.v.hana.common.exception.UserHttpCode;
+
+public class InvalidUserAccessException extends BaseCodeException {
+
+    public InvalidUserAccessException() {
+        super(UserHttpCode.EMPTY_USER);
+    }
+}

--- a/src/main/java/com/v/hana/repository/user/UserRepository.java
+++ b/src/main/java/com/v/hana/repository/user/UserRepository.java
@@ -1,8 +1,11 @@
 package com.v.hana.repository.user;
 
 import com.v.hana.entity.user.User;
+import jakarta.transaction.Transactional;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,7 +14,23 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUsername(String username);
 
+    Optional<User> findByUsernameAndPw(String username, String pw);
+
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByUsernameAndPw(String username, String pw);
+    void deleteUserByEmail(String email);
+
+    @Modifying
+    @Transactional
+    @Query(
+            value = "UPDATE users u SET u.pw = :newPassword WHERE u.email = :email",
+            nativeQuery = true)
+    void updatePasswordByEmail(String email, String newPassword);
+
+    @Modifying
+    @Transactional
+    @Query(
+            value = "UPDATE users u SET u.email = :newEmail WHERE u.username = :username",
+            nativeQuery = true)
+    void updateEmailByUsername(String username, String newEmail);
 }

--- a/src/main/java/com/v/hana/repository/user/UserRepository.java
+++ b/src/main/java/com/v/hana/repository/user/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByUsernameAndPw(String username, String pw);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,7 @@ logging:
   level:
     root: ${LOGGING_LEVEL}
   config: classpath:log4j2.xml
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  access-token-expiration: ${ACCESS_TOKEN_EXPIRATION}
+  refresh-token-expiration: ${REFRESH_TOKEN_EXPIRATION}

--- a/src/test/java/com/v/hana/controller/user/UserControllerTest.java
+++ b/src/test/java/com/v/hana/controller/user/UserControllerTest.java
@@ -11,10 +11,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.v.hana.auth.provider.JwtTokenProvider;
 import com.v.hana.common.annotation.MethodInfo;
 import com.v.hana.common.annotation.TypeInfo;
 import com.v.hana.docs.RestDocsTest;
 import com.v.hana.dto.user.UserJoinRequest;
+import com.v.hana.repository.user.UserRepository;
 import com.v.hana.service.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -22,14 +24,16 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-@TypeInfo(name = "ExampleControllerTest", description = "예시 컨트롤러 테스트 클래스")
+@TypeInfo(name = "UserControllerTest", description = "예시 컨트롤러 테스트 클래스")
 public class UserControllerTest extends RestDocsTest {
 
     private final UserService userService = mock(UserService.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
 
     @Override
     protected Object initializeController() {
-        return new UserController(userService);
+        return new UserController(userService, jwtTokenProvider, userRepository);
     }
 
     @MethodInfo(name = "userJoinSuccessPOST", description = "회원 가입 API 성공을 테스트합니다.")


### PR DESCRIPTION
## 📍 제목
JWT 인증 처리 & 사용자 정보 식별 어노테이션 

## 📃 목적
Jwt 인증 구현 및 토큰의 사용자 식별 기능 구현

## 📋 내용
로그인 성공시 액세스 토큰(15분)과 리프레시 토큰(24h)을 발급하고, 액세스 토큰 만료시 새 액세스 토큰을 발급합니다. 또한 Api에서 헤더에 담긴 인증 토큰으로부터 유저 정보를 추출하는 어노테이션을 추가합니다. 

## ❗ 체크리스트
<!-- 이번 PR을 제출하기 전에 확인할 사항들을 체크하세요. -->

- [ ] 코드가 의도한 대로 동작합니다.
- [ ] 기존 테스트를 모두 통과합니다.
- [ ] 추가된 새로운 테스트를 모두 통과합니다.
- [ ] 코드 스타일 규칙을 준수하였습니다.
- [ ] PR 템플릿 형식에 맞게 작성하였습니다.
- [ ] PR 이슈, 기여자, 라벨을 지정하였습니다.

## 📷 스크린샷 (선택)
<!-- 이번 PR에 대한 예시 화면을 스크린샷으로 첨부하세요. -->

## ❓ 추가 설명 (선택)
<!-- 이번 PR에 대한 추가 설명, 혹은 코드 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성하세요. -->

## 🔗 관련 문서 (선택)
<!-- 이번 PR과 관련된 문서나 참고 링크가 있다면 추가하세요. -->
